### PR TITLE
Update meshcentral-light-app.service

### DIFF
--- a/imageroot/systemd/user/meshcentral-light-app.service
+++ b/imageroot/systemd/user/meshcentral-light-app.service
@@ -32,11 +32,13 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/meshcentral-light-app.pid \
     --env WEBRTC=false \
     --env NODE_ENV=production \
     ${MESHCENTRAL_IMAGE}
-ExecStartPost=/usr/bin/podman exec meshcentral-light-app sed -i "s/\"cert\": \"meshcentral-light\"/\"cert\": \"${TRAEFIK_HOST}\"/" meshcentral-data/config.json
-ExecStartPost=/usr/bin/podman exec meshcentral-light-app sed -i "s/\"port\": 443/\"port\": 8989/" meshcentral-data/config.json
-ExecStartPost=/usr/bin/podman exec meshcentral-light-app sed -i "s/\"_aliasPort\": 443/\"aliasPort\": 443/" meshcentral-data/config.json
-ExecStartPost=/usr/bin/podman exec meshcentral-light-app sed -i "s/\"redirPort\": 80/\"redirPort\": 0/" meshcentral-data/config.json
-ExecStartPost=/usr/bin/podman exec meshcentral-light-app sed -i "s/\"TLSOffload\": false/\"TLSOffload\": \"127.0.0.1\"/" meshcentral-data/config.json
+
+ExecStartPost=/usr/bin/podman exec meshcentral-light-app sed -i "s|\"cert\": \"meshcentral-light\"|\"cert\": \"${TRAEFIK_HOST}\"|" meshcentral-data/config.json
+ExecStartPost=/usr/bin/podman exec meshcentral-light-app sed -i "s|\"port\": 443|\"port\": 8989|" meshcentral-data/config.json
+ExecStartPost=/usr/bin/podman exec meshcentral-light-app sed -i "s|\"_aliasPort\": 443|\"aliasPort\": 443|" meshcentral-data/config.json
+ExecStartPost=/usr/bin/podman exec meshcentral-light-app sed -i "s|\"redirPort\": 80|\"redirPort\": 0|" meshcentral-data/config.json
+ExecStartPost=/usr/bin/podman exec meshcentral-light-app sed -i "s|\"TLSOffload\": false|\"TLSOffload\": \"127.0.0.1\"|" meshcentral-data/config.json
+
 ExecStop=/usr/bin/podman exec meshcentral-light-app rm meshcentral-data/config.json
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/meshcentral-light-app.ctr-id -t 10
 ExecReload=/usr/bin/podman kill -s HUP meshcentral-light-app


### PR DESCRIPTION
Fix sed delimiter in ExecStartPost to prevent unterminated command error

Replaced all '/' delimiters with '|' in sed expressions to avoid issues when environment variables (e.g. TRAEFIK_HOST) contain slashes. This resolves container restart loop caused by unterminated sed expressions in systemd unit.